### PR TITLE
Deixando flexível os métodos que utilizam o método resourcePostRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,11 @@ $apiInstance = new Meli\Api\RestClientApi(
 );
 $resource = 'resource_example'; // string | for example: items
 $access_token = 'access_token_example'; // string |
+$options = ['headers' => ['access_token' => $access_token]]; // array |
 $body = new \stdClass; // object |
 
 try {
-    $apiInstance->resourcePost($resource, $access_token, $body);
+    $apiInstance->resourcePost($resource, $options, $body);
 } catch (Exception $e) {
     echo 'Exception when calling RestClientApi->resourcePost: ', $e->getMessage(), PHP_EOL;
 }

--- a/docs/Api/RestClientApi.md
+++ b/docs/Api/RestClientApi.md
@@ -143,10 +143,11 @@ $apiInstance = new Meli\Api\RestClientApi(
 );
 $resource = 'resource_example'; // string | 
 $access_token = 'access_token_example'; // string | 
+$options = ['headers' => ['access_token' => $access_token]]; // array |
 $body = new \stdClass; // object | 
 
 try {
-    $result = $apiInstance->resourcePost($resource, $access_token, $body);
+    $result = $apiInstance->resourcePost($resource, $options, $body);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling RestClientApi->resourcePost: ', $e->getMessage(), PHP_EOL;

--- a/examples/restClientPost.php
+++ b/examples/restClientPost.php
@@ -11,7 +11,7 @@ $apiInstance = new Meli\Api\RestClientApi(
 );
 $resource = 'items'; // A resource example like items, search, category, etc.
 $access_token = 'access_token_example'; // Your access token.
-
+$options = ['headers' => ['access_token' => $access_token]];
 $body = json_decode('{
   "title": "Item de test - No Ofertar",
   "category_id": "MLA5991",
@@ -72,7 +72,7 @@ $body = json_decode('{
 }');
 
 try {
-    $result = $apiInstance->resourcePost($resource, $access_token, $body);
+    $result = $apiInstance->resourcePost($resource, $options, $body);
     print_r($result);
 } catch (Exception $e) {
     echo 'Exception when calling RestClientApi->resourcePost: ', $e->getMessage(), PHP_EOL;

--- a/lib/Api/RestClientApi.php
+++ b/lib/Api/RestClientApi.php
@@ -709,16 +709,16 @@ class RestClientApi
      * Resourse path POST
      *
      * @param  string $resource resource (required)
-     * @param  string $access_token access_token (required)
+     * @param  array $options options (required)
      * @param  object $body body (required)
      *
      * @throws \Meli\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return object
      */
-    public function resourcePost($resource, $access_token, $body)
+    public function resourcePost($resource, $options, $body)
     {
-        list($response) = $this->resourcePostWithHttpInfo($resource, $access_token, $body);
+        list($response) = $this->resourcePostWithHttpInfo($resource, $options, $body);
         return $response;
     }
 
@@ -728,16 +728,16 @@ class RestClientApi
      * Resourse path POST
      *
      * @param  string $resource (required)
-     * @param  string $access_token (required)
+     * @param  array $options (required)
      * @param  object $body (required)
      *
      * @throws \Meli\ApiException on non-2xx response
      * @throws \InvalidArgumentException
      * @return array of object, HTTP status code, HTTP response headers (array of strings)
      */
-    public function resourcePostWithHttpInfo($resource, $access_token, $body)
+    public function resourcePostWithHttpInfo($resource, $options, $body)
     {
-        $request = $this->resourcePostRequest($resource, $access_token, $body);
+        $request = $this->resourcePostRequest($resource, $options, $body);
 
         try {
             $options = $this->createHttpClientOption();
@@ -818,15 +818,15 @@ class RestClientApi
      * Resourse path POST
      *
      * @param  string $resource (required)
-     * @param  string $access_token (required)
+     * @param  array $options (required)
      * @param  object $body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function resourcePostAsync($resource, $access_token, $body)
+    public function resourcePostAsync($resource, $options, $body)
     {
-        return $this->resourcePostAsyncWithHttpInfo($resource, $access_token, $body)
+        return $this->resourcePostAsyncWithHttpInfo($resource, $options, $body)
             ->then(
                 function ($response) {
                     return $response[0];
@@ -840,16 +840,16 @@ class RestClientApi
      * Resourse path POST
      *
      * @param  string $resource (required)
-     * @param  string $access_token (required)
+     * @param  array $options (required)
      * @param  object $body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Promise\PromiseInterface
      */
-    public function resourcePostAsyncWithHttpInfo($resource, $access_token, $body)
+    public function resourcePostAsyncWithHttpInfo($resource, $options, $body)
     {
         $returnType = 'object';
-        $request = $this->resourcePostRequest($resource, $access_token, $body);
+        $request = $this->resourcePostRequest($resource, $options, $body);
 
         return $this->client
             ->sendAsync($request, $this->createHttpClientOption())
@@ -889,14 +889,17 @@ class RestClientApi
      * Create request for operation 'resourcePost'
      *
      * @param  string $resource (required)
-     * @param  string $access_token (required)
+     * @param  array $options (required)
      * @param  object $body (required)
      *
      * @throws \InvalidArgumentException
      * @return \GuzzleHttp\Psr7\Request
      */
-    protected function resourcePostRequest($resource, $access_token, $body)
+    protected function resourcePostRequest($resource, $options, $body)
     {
+        $headers = isset($options['headers']) ? $options['headers'] : [];
+        $queryParams = isset($options['queryParams']) ? $options['queryParams'] : [];
+
         // verify the required parameter 'resource' is set
         if ($resource === null || (is_array($resource) && count($resource) === 0)) {
             throw new \InvalidArgumentException(
@@ -904,7 +907,7 @@ class RestClientApi
             );
         }
         // verify the required parameter 'access_token' is set
-        if ($access_token === null || (is_array($access_token) && count($access_token) === 0)) {
+        if ($headers['access_token'] === null || (is_array($headers['access_token']) && count($headers['access_token']) === 0)) {
             throw new \InvalidArgumentException(
                 'Missing the required parameter $access_token when calling resourcePost'
             );
@@ -918,7 +921,6 @@ class RestClientApi
 
         $resourcePath = '/{resource}';
         $formParams = [];
-        $queryParams = [];
         $headerParams = [];
         $httpBody = '';
         $multipart = false;
@@ -941,13 +943,13 @@ class RestClientApi
         if ($multipart) {
             $headers = $this->headerSelector->selectHeadersForMultipart(
                 ['application/json'],
-                $access_token
+                $headers['access_token']
             );
         } else {
             $headers = $this->headerSelector->selectHeaders(
                 ['application/json'],
-                ['application/json'],
-                $access_token
+                $headers['content_type'],
+                $headers['access_token']
             );
         }
 


### PR DESCRIPTION
Deixando mais flexível os métodos que utilizam o método resourcePostRequest pois quando precisamos passar mais algum parâmetro além dos que estavam sendo passados
não tínhamos essa possibilidade.